### PR TITLE
Update application setup block

### DIFF
--- a/readme-vars.yml
+++ b/readme-vars.yml
@@ -29,21 +29,28 @@ param_ports:
 # application setup block
 app_setup_block_enabled: true
 app_setup_block: "
-* When the application first runs, it will populate its /config (be sure you have user permissions matched between the host and the container)
+* When the application first runs, it will populate its /config
+  * (be sure you have user permissions matched between the host and the container by using PUID and PGID)
+  
+* Stop the container
 
-* From the host, edit `/config/config.js`, wherever you've mapped it, with the container stopped
+* Now from the host, edit `/config/config.js`, wherever you've mapped it
+  
+  * In most cases you want the value `public: false` to allow named users only
+  
+  * Setting the two prefetch values to true improves usability, but uses more storage
 
-** In most cases you want the value `public: false` to allow named users only
-** Setting the two prefetch values to true improves usability, but uses more storage
-
-* Once you have the configuration you want, start the container again
+* Once you have the configuration you want, save it and start the container again
 
 * For each user, run the command
-** `docker exec -it thelounge s6-setuidgid abc thelounge add <user>` ## sorry this is so complicated but leaving things out causes thelounge to complain about running as root
-** You will be prompted to enter a password that will not be echoed.
-** Saving logs to disk is the default, this consumes more space but allows scrollback.
 
-* To log in to the application, browse to http://<hostip>:9000. ## if you want https, use a reverse proxy
+  * `docker exec -it thelounge s6-setuidgid abc thelounge add <user>`
+  
+  * You will be prompted to enter a password that will not be echoed.
+  
+  * Saving logs to disk is the default, this consumes more space but allows scrollback.
+
+* To log in to the application, browse to http://<hostip>:9000
 
 * You should now be prompted for a username and password on the webinterface.
 

--- a/readme-vars.yml
+++ b/readme-vars.yml
@@ -29,19 +29,25 @@ param_ports:
 # application setup block
 app_setup_block_enabled: true
 app_setup_block: "
-* To log in to the application, browse to https://<hostip>:9000.
+* When the application first runs, it will populate its /config (be sure you have user permissions matched between the host and the container)
 
-* To setup user account(s) edit `/config/config.json` 
-  
-* Change the value `public: true,` to `public: false,`
- 
-* restart the container and enter the following from the command line of the host:
-  
-* `docker exec -it thelounge thelounge add <user>`
-  
-* Enter a password when prompted, refresh your browser.
+* From the host, edit `/config/config.js`, wherever you've mapped it, with the container stopped
 
-* You should now be prompted for a password on the webinterface.
+** In most cases you want the value `public: false` to allow named users only
+** Setting the two prefetch values to true improves usability, but uses more storage
+
+* Once you have the configuration you want, start the container again
+
+* For each user, run the command
+** `docker exec -it thelounge s6-setuidgid abc thelounge add <user>` ## sorry this is so complicated but leaving things out causes thelounge to complain about running as root
+** You will be prompted to enter a password that will not be echoed.
+** Saving logs to disk is the default, this consumes more space but allows scrollback.
+
+* To log in to the application, browse to http://<hostip>:9000. ## if you want https, use a reverse proxy
+
+* You should now be prompted for a username and password on the webinterface.
+
+* Once logged in, you can add an IRC network. Some defaults are preset for Freenode.
 "
 
 # changelog


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

[linuxserverurl]: https://linuxserver.io
[![linuxserver.io](https://raw.githubusercontent.com/linuxserver/docker-templates/master/linuxserver.io/img/linuxserver_medium.png)][linuxserverurl]
	

<!--- Before submitting a pull request please check the following -->

<!---  If this is a fix for a typo in code or documentation in the README please file an issue and let us sort it out we do not need a PR  --> 
<!---  Ask yourself if this modification is something the whole userbase will benefit from, if this is a specific change for corner case functionality or plugins please look at making a Docker Mod or local script  https://blog.linuxserver.io/2019/09/14/customizing-our-containers/ -->
<!---  That if the PR is addressing an existing issue include, closes #<issue number> , in the body of the PR commit message   -->
<!---  You have included links to any files / patches etc your PR may be using in the body of the PR commit message -->
<!--- We maintain a changelog of major revisions to the container at the end of readme-vars.yml in the root of this repository, please add your changes there if appropriate -->

Name of configuration file is config.js not config.json.

Want to run container to populate /config first before attempting to edit config.js.

Want the container to be stopped while you edit config.js.

A more complicated command is needed to add users. Using 'su' might be more understandable but either way the username 'abc' built into the container or the PUID has to be used here to avoid confusing complaints from theLounge running as root. A better explanation of the password entry and the question asked about logging messages.

By default, theLounge container is not set up for https access, so advise logging in locally with http.

Provide a little more guidance about how to use theLounge once logged in, since it starts with no networks.


<!--- Coding guidelines: -->
<!--- 1. Installed packages in the Dockerfiles should be in alphabetical order -->
<!--- 2. Changes to Dockerfile should be replicated in Dockerfile.armhf and Dockerfile.aarch64 if applicable -->
<!--- 3. Indentation style (tabs vs 4 spaces vs 1 space) should match the rest of the document -->
<!--- 4. Readme is auto generated from readme-vars.yml, make your changes there -->

------------------------------

We welcome all PR’s though this doesn’t guarantee it will be accepted.

## Description:
<!--- Describe your changes in detail -->
Name of configuration file is config.js not config.json.

Want to run container to populate /config first before attempting to edit config.js.

Want the container to be stopped while you edit config.js.

A more complicated command is needed to add users. Using 'su' might be more understandable but either way the username 'abc' built into the container or the PUID has to be used here to avoid confusing complaints from theLounge running as root. A better explanation of the password entry and the question asked about logging messages.

By default, theLounge container is not set up for https access, so advise logging in locally with http.

Provide a little more guidance about how to use theLounge once logged in, since it starts with no networks.

## Benefits of this PR and context:
The errors in the current application setup block will cause less sophisticated users to be stymied in trying to set up the container for actual use.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Well, here's a problem. I would need to do a build step to turn the readme-vars.yml file into the actual readme.md to be able to see that I've not missed a bit of punctuation. I have copy-pasted the changed block into the Readme.md and previewed it to make sure I don't have any obvious Markdown errors.

As for the procedure I've outlined, I've tested it against the latest version of the container to be sure I have the steps in the right order. I've set up theLounge many times, though usually not as a container.

## Source / References:
<!--- Please include any forum posts/github links relevant to the PR -->
